### PR TITLE
Update README with CI pipeline diagram and release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,35 @@ graph TB
 | `example_package_msgs` | Custom service (`Example.srv`) and action (`Example.action`) interface definitions |
 | `example_package_ros` | ROS2 nodes using `Example` class from `assignment_example_pkg` |
 
+## CI Pipeline
+
+The CI workflow runs on every pull request to `main` and every push to `main`. Linting gates the build-and-test stage - the build does not start until all ament linters pass. Test results are published directly on the PR.
+
+```mermaid
+%%{init: {'theme': 'dark', 'flowchart': {'curve': 'linear'}}}%%
+graph LR
+    classDef primary fill:#2d5986,stroke:#4a90d9,stroke-width:1px,color:#e0e0e0,rx:8,ry:8
+    classDef secondary fill:#1a3a5c,stroke:#3d7ab5,stroke-width:1px,color:#e0e0e0,rx:8,ry:8
+    classDef accent fill:#2d7d46,stroke:#4caf50,stroke-width:1px,color:#e0e0e0,rx:8,ry:8
+
+    LINT[Lint<br/>ament_flake8<br/>ament_pep257<br/>ament_copyright]:::primary -->|pass| BUILD[Build & Test<br/>in ros-ci:humble]:::secondary
+    BUILD --> REPORT[Results on PR]:::accent
+```
+
+## Release
+
+Releases are driven by Git tags. Pushing a tag that matches `v*` triggers the shared release workflow from [ci-workflows](https://github.com/calebjakemossey/ci-workflows), which builds a Docker image and creates a GitHub Release automatically.
+
+```bash
+git tag v1.0.1 && git push origin v1.0.1
+```
+
+The resulting image is published to GHCR and can be pulled with:
+
+```bash
+docker pull ghcr.io/calebjakemossey/assignment-example-ros-pkg:v1.0.1
+```
+
 ## Getting Started
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for workspace setup, building, and testing instructions.
@@ -43,7 +72,7 @@ Refer to [example_package_ros/README.md](example_package_ros/README.md) for deta
 
 ## Development with Docker
 
-The recommended way to build and test is using the CI Docker image:
+The recommended way to build and test is using the CI Docker image, which provides the same environment used by the pipeline:
 
 ```bash
 docker pull ghcr.io/calebjakemossey/ros-ci:humble
@@ -59,4 +88,4 @@ source install/local_setup.bash
 colcon test && colcon test-result --verbose
 ```
 
-This provides the same environment used by CI, ensuring local results match pipeline results.
+This ensures local results match pipeline results.


### PR DESCRIPTION
## Summary

Adds missing CI pipeline and release documentation to the README, because contributors and reviewers currently have no visibility into how the pipeline stages are structured or how to trigger a release.

## Changes

- **CI Pipeline section**: Added a mermaid diagram (dark theme, linear curve) illustrating the sequential lint-then-build-and-test flow, along with a description of when the workflow runs and how results surface on PRs - this gives contributors immediate clarity on what the pipeline does without needing to read the workflow YAML
- **Release section**: Documents the tag-driven release process and the GHCR image pull command (`ghcr.io/calebjakemossey/assignment-example-ros-pkg:v1.0.1`) - new contributors otherwise have no way to discover how releases work
- **Docker section wording**: Moved the "same environment as pipeline" note into the opening sentence and removed the redundant closing line, because the information was stated twice

## Testing

Visual inspection of the rendered mermaid diagrams and markdown on GitHub.